### PR TITLE
feat: 쿠팡 상품 수정 및 삭제 기능 구현 및 로깅 개선

### DIFF
--- a/app/api/endpoints/coupang.py
+++ b/app/api/endpoints/coupang.py
@@ -356,7 +356,7 @@ async def register_product_endpoint(
 
 
 @router.put("/products/{product_id}", status_code=200)
-async def update_coupang_product_endpoint(
+def update_coupang_product_endpoint(
     product_id: uuid.UUID,
     session: Session = Depends(get_session),
 ):
@@ -378,7 +378,7 @@ async def update_coupang_product_endpoint(
 
 
 @router.delete("/products/{seller_product_id}", status_code=200)
-async def delete_coupang_product_endpoint(
+def delete_coupang_product_endpoint(
     seller_product_id: str,
     session: Session = Depends(get_session),
 ):


### PR DESCRIPTION
# 쿠팡 상품 관리 기능 고도화

쿠팡 상품의 수정 및 삭제 기능을 구현하고, API 통신 과정을 추적하기 위한 로깅 기능을 강화하였습니다.

## 주요 변경 사항

### 1. 상품 관리 엔드포인트 추가
- `PUT /api/coupang/products/{product_id}`: 쿠팡에 등록된 상품 정보를 최신 데이터로 업데이트합니다.
- `DELETE /api/coupang/products/{seller_product_id}`: 모든 옵션 판매 중지 처리 후 상품을 삭제합니다.

### 2. 쿠팡 동기화 로직 개선
- 상품 수정 시 필수 필드(고시정보, 반품지 주소) 누락 문제를 해결하기 위해, 수정 전 카테고리 메타데이터 및 반품지 상세 정보를 동적으로 조회하여 반영합니다.
- 로깅 함수(`_log_fetch`)를 강화하여 트랜잭션 롤백 시에도 독립적인 세션으로 API 기록이 남도록 보완하였습니다.

### 3. 검증 환경 구축
- API 호출 결과를 `SupplierRawFetchLog`를 통해 상세히 확인할 수 있어, 등록 실패 원인(이미지 수 부족 등)을 명확히 추적할 수 있습니다.

## 테스트 결과
- 특정 상품(`a8a3388d-319a-4700-892f-a327f3183602`)에 대해 실제 수정 및 삭제 작업을 수행하여 성공을 확인하였습니다.
