### PR TITLE
feat: CI 백엔드 검증 강화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,24 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
+          cache-dependency-path: requirements.txt
 
       - name: 의존성 설치
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: 의존성 무결성 체크
+        run: pip check
+
       - name: 파이썬 컴파일 체크
         run: python -m compileall app scripts
+
+      - name: 백엔드 테스트 실행(있으면)
+        run: |
+          if [ -d "tests" ]; then
+            echo "tests 디렉토리 존재: unittest 실행"
+            python -m unittest discover -s tests -p "test*.py" -v
+          else
+            echo "tests 디렉토리 없음: 스킵"
+          fi


### PR DESCRIPTION
## 변경 요약
- backend job에 `pip check`(의존성 무결성) 추가
- `tests/` 디렉토리가 있을 때만 `unittest discover` 실행(없으면 스킵)
- setup-python `cache-dependency-path`에 `requirements.txt` 지정

## 의도
- pytest/ruff 등 추가 의존성 없이도 CI에서 기본적인 품질 게이트를 강화합니다.

## 확인 방법
- PR CI가 통과하는지 확인합니다.
- `tests/`가 추가되는 시점부터 자동으로 unittest가 실행됩니다.
