### PR TITLE
feat: CI ruff 검사 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Ruff 설치
+        run: python -m pip install ruff
+
+      - name: Ruff 체크(F821)
+        run: python -m ruff check --select F821 app
+
       - name: 의존성 무결성 체크
         run: pip check
 


### PR DESCRIPTION
## 변경 요약
- backend job에 Ruff 정적 검사 단계 추가
  - 초기 도입 부담을 낮추기 위해 `F821(정의되지 않은 이름)`만 검사합니다.

## 의도
- 실행 전 단계에서 치명적인 NameError류(정의되지 않은 심볼) 문제를 CI에서 빠르게 감지합니다.

## 확인 방법
- PR CI가 통과하는지 확인합니다.
