### PR TITLE
feat: 상품 등록 및 마켓 상품 관리 화면 추가

### DIFF
--- a/app/api/endpoints/market.py
+++ b/app/api/endpoints/market.py
@@ -1,0 +1,168 @@
+"""
+마켓 상품 관리 API 엔드포인트
+- 마켓에 등록된 상품 목록 조회
+- MarketListing과 Product 조인하여 상품 정보 반환
+"""
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import select, func
+import uuid
+
+from app.db import get_session
+from app.models import Product, MarketListing, MarketAccount
+
+router = APIRouter()
+
+
+
+@router.get("/listings", status_code=200)
+def list_market_listings(
+    session: Session = Depends(get_session),
+    market_code: str = Query(default="COUPANG", alias="marketCode"),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+):
+    """
+    마켓에 등록된 상품 목록을 조회합니다.
+    MarketListing 테이블을 기준으로 조회합니다.
+    """
+    # 활성 계정 조회
+    stmt_account = select(MarketAccount).where(
+        MarketAccount.market_code == market_code,
+        MarketAccount.is_active == True
+    )
+    account = session.scalars(stmt_account).first()
+    
+    if not account:
+        return {
+            "items": [],
+            "total": 0,
+            "limit": limit,
+            "offset": offset,
+            "message": f"활성 상태의 {market_code} 계정이 없습니다."
+        }
+    
+    # 카운트 쿼리
+    count_stmt = select(func.count(MarketListing.id)).where(
+        MarketListing.market_account_id == account.id
+    )
+    if status:
+        count_stmt = count_stmt.where(MarketListing.status == status)
+    total = session.scalar(count_stmt) or 0
+    
+    # 목록 쿼리
+    stmt = (
+        select(MarketListing)
+        .where(MarketListing.market_account_id == account.id)
+        .order_by(MarketListing.linked_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    if status:
+        stmt = stmt.where(MarketListing.status == status)
+    
+    listings = session.scalars(stmt).all()
+    
+    items = []
+    for listing in listings:
+        items.append({
+            "id": str(listing.id),
+            "productId": str(listing.product_id),
+            "marketAccountId": str(listing.market_account_id),
+            "marketItemId": listing.market_item_id,
+            "status": listing.status,
+            "linkedAt": listing.linked_at.isoformat() if listing.linked_at else None,
+        })
+    
+    return {
+        "items": items,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+@router.get("/products", status_code=200)
+def list_market_products(
+    session: Session = Depends(get_session),
+    market_code: str = Query(default="COUPANG", alias="marketCode"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+):
+    """
+    마켓에 등록된 상품 목록을 Product 정보와 함께 조회합니다.
+    Product.status가 ACTIVE인 상품을 조회합니다.
+    """
+    from app.db import get_session as get_dropship_session
+    from app.session_factory import session_factory
+    
+    # 활성 계정 조회
+    stmt_account = select(MarketAccount).where(
+        MarketAccount.market_code == market_code,
+        MarketAccount.is_active == True
+    )
+    account = session.scalars(stmt_account).first()
+    
+    if not account:
+        return {
+            "items": [],
+            "total": 0,
+            "limit": limit,
+            "offset": offset,
+        }
+    
+    # MarketListing 조회
+    stmt = (
+        select(MarketListing)
+        .where(MarketListing.market_account_id == account.id)
+        .order_by(MarketListing.linked_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    listings = session.scalars(stmt).all()
+    
+    # Product 정보 조회 (Dropship DB에서)
+    product_ids = [listing.product_id for listing in listings]
+    
+    items = []
+    
+    # Dropship DB에서 Product 정보 조회
+    with session_factory() as dropship_session:
+        if product_ids:
+            products_stmt = select(Product).where(Product.id.in_(product_ids))
+            products = dropship_session.scalars(products_stmt).all()
+            product_map = {p.id: p for p in products}
+        else:
+            product_map = {}
+        
+        for listing in listings:
+            product = product_map.get(listing.product_id)
+            items.append({
+                "id": str(listing.id),
+                "productId": str(listing.product_id),
+                "marketItemId": listing.market_item_id,
+                "status": listing.status,
+                "linkedAt": listing.linked_at.isoformat() if listing.linked_at else None,
+                # Product 정보
+                "name": product.name if product else None,
+                "processedName": product.processed_name if product else None,
+                "sellingPrice": product.selling_price if product else 0,
+                "processedImageUrls": product.processed_image_urls if product else [],
+                "productStatus": product.status if product else None,
+            })
+    
+    # 총 개수
+    count_stmt = select(func.count(MarketListing.id)).where(
+        MarketListing.market_account_id == account.id
+    )
+    total = session.scalar(count_stmt) or 0
+    
+    return {
+        "items": items,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "marketCode": market_code,
+        "accountId": str(account.id),
+    }

--- a/app/api/endpoints/products.py
+++ b/app/api/endpoints/products.py
@@ -82,9 +82,21 @@ def get_product_stats(
     }
 
 @router.get("/", response_model=List[ProductResponse])
-def list_products(session: Session = Depends(get_session)):
+def list_products(
+    session: Session = Depends(get_session),
+    processing_status: str | None = Query(default=None, alias="processingStatus"),
+    status: str | None = Query(default=None),
+):
     """모든 상품 목록을 조회합니다."""
-    stmt = select(Product).order_by(Product.created_at.desc())
+    stmt = select(Product)
+
+    if processing_status:
+        stmt = stmt.where(Product.processing_status == processing_status)
+
+    if status:
+        stmt = stmt.where(Product.status == status)
+
+    stmt = stmt.order_by(Product.created_at.desc())
     products = session.scalars(stmt).all()
     return products
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from app.ownerclan_client import OwnerClanClient
 from app.ownerclan_sync import start_background_ownerclan_job
 from app.session_factory import session_factory
 from app.settings import settings
-from app.api.endpoints import sourcing, products, coupang, settings as settings_endpoint, suppliers as suppliers_endpoint, benchmarks
+from app.api.endpoints import sourcing, products, coupang, settings as settings_endpoint, suppliers as suppliers_endpoint, benchmarks, market
 from app.schemas.product import ProductResponse
 
 app = FastAPI()
@@ -27,6 +27,8 @@ app.include_router(products.router, prefix="/api/products", tags=["Products"])
 app.include_router(coupang.router, prefix="/api/coupang", tags=["Coupang"])
 app.include_router(settings_endpoint.router, prefix="/api/settings", tags=["Settings"])
 app.include_router(suppliers_endpoint.router, prefix="/api/suppliers", tags=["Suppliers"])
+app.include_router(market.router, prefix="/api/market", tags=["Market"])
+
 
 # Next.js(/api/products) 경로 정규화로 인해 백엔드가 /api/products → /api/products/ 로 307 redirect를 내보내면
 # 브라우저가 8888 오리진으로 따라가며 CORS에 막혀 Axios가 Network Error가 날 수 있다.

--- a/frontend/src/app/market-products/page.tsx
+++ b/frontend/src/app/market-products/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+    Loader2,
+    Search,
+    ShoppingBag,
+    ExternalLink,
+    RotateCw,
+    AlertCircle,
+    CheckCircle2,
+    Edit,
+    Trash2,
+    MoreVertical,
+    ArrowLeft
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Badge } from "@/components/ui/Badge";
+import api from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface MarketProduct {
+    id: string;
+    productId: string;
+    marketItemId: string;
+    status: string;
+    linkedAt: string | null;
+    name: string | null;
+    processedName: string | null;
+    sellingPrice: number;
+    processedImageUrls: string[] | null;
+    productStatus: string | null;
+}
+
+export default function MarketProductsPage() {
+    const [items, setItems] = useState<MarketProduct[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useState("");
+    const [total, setTotal] = useState(0);
+
+    const fetchMarketProducts = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await api.get("/market/products", {
+                params: { limit: 100 }
+            });
+            const data = response.data;
+            setItems(Array.isArray(data.items) ? data.items : []);
+            setTotal(data.total || 0);
+        } catch (e) {
+            console.error("Failed to fetch market products", e);
+            setError("마켓 상품 목록을 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchMarketProducts();
+    }, []);
+
+    // 쿠팡 상품 상세 보기 (새 탭)
+    const handleViewOnCoupang = (sellerProductId: string) => {
+        // 쿠팡 Wing 판매자 센터 상품 조회 URL (로그인 필요)
+        window.open(`https://wing.coupang.com/product/${sellerProductId}`, '_blank');
+    };
+
+    const filteredItems = items.filter(item =>
+        (item.name || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+        (item.processedName || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+        item.marketItemId.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    const formatDate = (dateStr: string | null) => {
+        if (!dateStr) return "-";
+        const date = new Date(dateStr);
+        return date.toLocaleDateString('ko-KR', {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit'
+        });
+    };
+
+    return (
+        <div className="space-y-8 animate-in fade-in duration-500">
+            {/* 헤더 섹션 */}
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-6 border-b">
+                <div className="space-y-2">
+                    <div className="flex items-center gap-2 text-primary font-medium">
+                        <ShoppingBag className="h-5 w-5" />
+                        <span>Market Products</span>
+                    </div>
+                    <h1 className="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+                        마켓 상품
+                    </h1>
+                    <p className="text-muted-foreground max-w-2xl">
+                        쿠팡에 등록된 상품 목록입니다. 등록된 상품의 상태를 확인하고 관리할 수 있습니다.
+                    </p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <Button
+                        variant="outline"
+                        className="rounded-xl h-11 px-6 border-2 hover:bg-accent"
+                        onClick={() => window.location.href = '/registration'}
+                    >
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        등록 페이지
+                    </Button>
+                    <Button variant="outline" className="rounded-xl h-11 px-6 border-2 hover:bg-accent" onClick={fetchMarketProducts}>
+                        <RotateCw className="mr-2 h-4 w-4" />
+                        새로고침
+                    </Button>
+                </div>
+            </div>
+
+            {/* 통계 */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <Card className="border-none shadow-md bg-gradient-to-br from-primary/10 to-primary/5">
+                    <CardContent className="p-6">
+                        <div className="flex items-center gap-4">
+                            <div className="h-12 w-12 rounded-xl bg-primary/20 flex items-center justify-center">
+                                <ShoppingBag className="h-6 w-6 text-primary" />
+                            </div>
+                            <div>
+                                <p className="text-sm text-muted-foreground">등록된 상품</p>
+                                <p className="text-3xl font-bold">{total}</p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card className="border-none shadow-md bg-gradient-to-br from-emerald-500/10 to-emerald-600/5">
+                    <CardContent className="p-6">
+                        <div className="flex items-center gap-4">
+                            <div className="h-12 w-12 rounded-xl bg-emerald-500/20 flex items-center justify-center">
+                                <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+                            </div>
+                            <div>
+                                <p className="text-sm text-muted-foreground">활성 상품</p>
+                                <p className="text-3xl font-bold">{items.filter(i => i.status === "ACTIVE").length}</p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            {/* 검색 */}
+            <div className="flex flex-col md:flex-row gap-4 items-center">
+                <div className="relative flex-1 group w-full">
+                    <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground group-focus-within:text-primary transition-colors" />
+                    <Input
+                        placeholder="상품명 또는 상품 ID로 검색..."
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        className="pl-12 h-12 rounded-2xl border-none bg-accent/50 focus-visible:ring-2 focus-visible:ring-primary/20 transition-all text-base w-full"
+                    />
+                </div>
+            </div>
+
+            {/* 상품 목록 */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {loading ? (
+                    <div className="col-span-full h-80 flex flex-col items-center justify-center space-y-4">
+                        <div className="h-12 w-12 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
+                        <p className="text-muted-foreground font-medium animate-pulse">마켓 상품을 불러오는 중...</p>
+                    </div>
+                ) : error ? (
+                    <Card className="col-span-full border-2 border-destructive/20 bg-destructive/5">
+                        <CardContent className="flex flex-col items-center py-12 text-center">
+                            <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+                            <h3 className="text-xl font-bold mb-2">오류 발생</h3>
+                            <p className="text-muted-foreground">{error}</p>
+                            <Button className="mt-6 rounded-xl" variant="outline" onClick={fetchMarketProducts}>다시 시도</Button>
+                        </CardContent>
+                    </Card>
+                ) : filteredItems.length === 0 ? (
+                    <div className="col-span-full py-20 text-center">
+                        <div className="h-20 w-20 bg-accent rounded-full flex items-center justify-center mx-auto mb-6">
+                            <ShoppingBag className="h-10 w-10 text-muted-foreground/50" />
+                        </div>
+                        <h3 className="text-2xl font-bold text-foreground mb-2">등록된 상품이 없습니다</h3>
+                        <p className="text-muted-foreground">상품 등록 페이지에서 상품을 쿠팡에 등록해 주세요.</p>
+                        <Button className="mt-8 rounded-xl h-11 px-8" onClick={() => window.location.href = '/registration'}>
+                            상품 등록하러 가기
+                        </Button>
+                    </div>
+                ) : (
+                    filteredItems.map((item) => (
+                        <Card
+                            key={item.id}
+                            className="group overflow-hidden border-none shadow-md hover:shadow-2xl transition-all duration-500 rounded-3xl bg-card/40 backdrop-blur-xl border border-white/10"
+                        >
+                            {/* 이미지 미리보기 */}
+                            <div className="aspect-[4/3] relative overflow-hidden bg-muted">
+                                {item.processedImageUrls && item.processedImageUrls.length > 0 ? (
+                                    <img
+                                        src={item.processedImageUrls[0]}
+                                        alt={item.name || "상품"}
+                                        className="object-cover w-full h-full transition-transform duration-700 group-hover:scale-110"
+                                    />
+                                ) : (
+                                    <div className="w-full h-full flex flex-col items-center justify-center text-muted-foreground/30 space-y-2">
+                                        <ShoppingBag className="h-12 w-12" />
+                                        <span className="text-xs font-medium uppercase tracking-widest">No Image</span>
+                                    </div>
+                                )}
+
+                                {/* 상태 배지 */}
+                                <div className="absolute top-4 left-4">
+                                    <Badge
+                                        className={cn(
+                                            "backdrop-blur-md border-0 text-[10px] font-bold tracking-widest uppercase py-1",
+                                            item.status === "ACTIVE" ? "bg-emerald-500/80 text-white" : "bg-gray-500/80 text-white"
+                                        )}
+                                    >
+                                        {item.status === "ACTIVE" ? "판매중" : item.status}
+                                    </Badge>
+                                </div>
+
+                                {/* 외부 링크 */}
+                                <div className="absolute top-4 right-4 opacity-0 group-hover:opacity-100 transition-opacity">
+                                    <Button
+                                        size="icon"
+                                        variant="secondary"
+                                        className="h-9 w-9 rounded-full shadow-lg"
+                                        onClick={() => handleViewOnCoupang(item.marketItemId)}
+                                    >
+                                        <ExternalLink className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            </div>
+
+                            <CardContent className="p-5 space-y-4">
+                                <div className="space-y-1">
+                                    <h3 className="font-bold text-lg leading-tight truncate group-hover:text-primary transition-colors">
+                                        {item.processedName || item.name || "상품명 없음"}
+                                    </h3>
+                                    <p className="text-xs text-muted-foreground truncate">
+                                        쿠팡 ID: {item.marketItemId}
+                                    </p>
+                                </div>
+
+                                <div className="flex items-center justify-between text-sm py-3 border-y border-foreground/5">
+                                    <div className="flex flex-col">
+                                        <span className="text-muted-foreground text-[10px] uppercase font-bold tracking-tighter">판매가</span>
+                                        <span className="font-bold text-base text-primary">{item.sellingPrice.toLocaleString()}원</span>
+                                    </div>
+                                    <div className="flex flex-col items-end">
+                                        <span className="text-muted-foreground text-[10px] uppercase font-bold tracking-tighter">등록일</span>
+                                        <span className="text-sm">{formatDate(item.linkedAt)}</span>
+                                    </div>
+                                </div>
+                            </CardContent>
+
+                            <CardFooter className="px-5 pb-5 pt-0 gap-2">
+                                <Button
+                                    className="flex-1 rounded-2xl font-bold bg-accent hover:bg-accent/80 text-foreground border-none transition-all"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => handleViewOnCoupang(item.marketItemId)}
+                                >
+                                    <ExternalLink className="mr-2 h-4 w-4" />
+                                    쿠팡에서 보기
+                                </Button>
+                            </CardFooter>
+                        </Card>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/app/registration/page.tsx
+++ b/frontend/src/app/registration/page.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+    Loader2,
+    Search,
+    Filter,
+    Upload,
+    CheckCircle2,
+    Clock,
+    XCircle,
+    AlertCircle,
+    RotateCw,
+    ExternalLink,
+    Sparkles,
+    ShoppingCart,
+    ArrowRight
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Badge } from "@/components/ui/Badge";
+import api from "@/lib/api";
+import { Product } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface RegistrationProduct extends Product {
+    imagesCount: number;
+}
+
+export default function RegistrationPage() {
+    const [items, setItems] = useState<RegistrationProduct[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [searchTerm, setSearchTerm] = useState("");
+    const [registeringIds, setRegisteringIds] = useState<Set<string>>(new Set());
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [bulkRegistering, setBulkRegistering] = useState(false);
+
+    // 가공 완료 + DRAFT 상태 상품 조회
+    const fetchProducts = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await api.get("/products/", {
+                params: {
+                    processingStatus: "COMPLETED",
+                    status: "DRAFT"
+                }
+            });
+            const products = Array.isArray(response.data) ? response.data : [];
+            // 필터: processing_status가 COMPLETED이고 status가 DRAFT인 상품
+            const filtered = products.filter((p: Product) =>
+                p.processing_status === "COMPLETED" && p.status === "DRAFT"
+            ).map((p: Product) => ({
+                ...p,
+                imagesCount: p.processed_image_urls?.length || 0
+            }));
+            setItems(filtered);
+        } catch (e) {
+            console.error("Failed to fetch products", e);
+            setError("상품 목록을 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchProducts();
+    }, []);
+
+    // 개별 상품 쿠팡 등록
+    const handleRegister = async (productId: string) => {
+        if (registeringIds.has(productId)) return;
+
+        setRegisteringIds(prev => new Set(prev).add(productId));
+        try {
+            await api.post(`/coupang/register/${productId}`, null, {
+                params: { autoFix: true, wait: true }
+            });
+            // 등록 성공 시 목록에서 제거
+            setItems(prev => prev.filter(item => item.id !== productId));
+            setSelectedIds(prev => {
+                const next = new Set(prev);
+                next.delete(productId);
+                return next;
+            });
+        } catch (e: any) {
+            console.error("Registration failed", e);
+            const detail = e.response?.data?.detail;
+            const message = typeof detail === 'string' ? detail : detail?.message || "등록 실패";
+            alert(`등록 실패: ${message}`);
+        } finally {
+            setRegisteringIds(prev => {
+                const next = new Set(prev);
+                next.delete(productId);
+                return next;
+            });
+        }
+    };
+
+    // 일괄 등록
+    const handleBulkRegister = async () => {
+        if (selectedIds.size === 0) {
+            alert("등록할 상품을 선택해주세요.");
+            return;
+        }
+
+        setBulkRegistering(true);
+        try {
+            const productIds = Array.from(selectedIds);
+            await api.post("/coupang/register/bulk",
+                { productIds },
+                { params: { autoFix: true, wait: true, limit: 50 } }
+            );
+            // 등록 완료된 상품들 목록에서 제거
+            setItems(prev => prev.filter(item => !selectedIds.has(item.id)));
+            setSelectedIds(new Set());
+            alert("일괄 등록이 완료되었습니다.");
+        } catch (e: any) {
+            console.error("Bulk registration failed", e);
+            alert("일괄 등록 중 오류가 발생했습니다.");
+        } finally {
+            setBulkRegistering(false);
+        }
+    };
+
+    // 전체 선택/해제
+    const toggleSelectAll = (checked: boolean) => {
+        if (checked) {
+            const readyIds = filteredItems
+                .filter(item => item.imagesCount >= 5)
+                .map(item => item.id);
+            setSelectedIds(new Set(readyIds));
+        } else {
+            setSelectedIds(new Set());
+        }
+    };
+
+    // 개별 선택/해제
+    const toggleSelect = (id: string, checked: boolean) => {
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (checked) {
+                next.add(id);
+            } else {
+                next.delete(id);
+            }
+            return next;
+        });
+    };
+
+    // 등록 가능 여부 체크 (이미지 5장 이상)
+    const isReadyForRegistration = (item: RegistrationProduct) => {
+        return item.imagesCount >= 5;
+    };
+
+    const filteredItems = items.filter(item =>
+        item.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        item.processed_name?.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
+    const readyCount = filteredItems.filter(isReadyForRegistration).length;
+    const notReadyCount = filteredItems.length - readyCount;
+
+    return (
+        <div className="space-y-8 animate-in fade-in duration-500">
+            {/* Header Section */}
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-6 border-b">
+                <div className="space-y-2">
+                    <div className="flex items-center gap-2 text-primary font-medium">
+                        <Upload className="h-5 w-5" />
+                        <span>Market Registration</span>
+                    </div>
+                    <h1 className="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+                        상품 등록
+                    </h1>
+                    <p className="text-muted-foreground max-w-2xl">
+                        가공 완료된 상품을 쿠팡 마켓에 등록합니다. 이미지가 5장 이상인 상품만 등록 가능합니다.
+                    </p>
+                </div>
+                <div className="flex items-center gap-3">
+                    <Button variant="outline" className="rounded-xl h-11 px-6 border-2 hover:bg-accent" onClick={fetchProducts}>
+                        <RotateCw className="mr-2 h-4 w-4" />
+                        새로고침
+                    </Button>
+                    <Button
+                        className="rounded-xl h-11 px-6 shadow-lg shadow-primary/20 hover:scale-105 transition-transform"
+                        onClick={handleBulkRegister}
+                        disabled={selectedIds.size === 0 || bulkRegistering}
+                    >
+                        {bulkRegistering ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                            <Sparkles className="mr-2 h-4 w-4" />
+                        )}
+                        선택 등록 ({selectedIds.size})
+                    </Button>
+                </div>
+            </div>
+
+            {/* Stats Cards */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Card className="border-none shadow-md bg-gradient-to-br from-blue-500/10 to-blue-600/5">
+                    <CardContent className="p-6">
+                        <div className="flex items-center gap-4">
+                            <div className="h-12 w-12 rounded-xl bg-blue-500/20 flex items-center justify-center">
+                                <Clock className="h-6 w-6 text-blue-500" />
+                            </div>
+                            <div>
+                                <p className="text-sm text-muted-foreground">등록 대기</p>
+                                <p className="text-3xl font-bold">{filteredItems.length}</p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card className="border-none shadow-md bg-gradient-to-br from-emerald-500/10 to-emerald-600/5">
+                    <CardContent className="p-6">
+                        <div className="flex items-center gap-4">
+                            <div className="h-12 w-12 rounded-xl bg-emerald-500/20 flex items-center justify-center">
+                                <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+                            </div>
+                            <div>
+                                <p className="text-sm text-muted-foreground">등록 가능</p>
+                                <p className="text-3xl font-bold">{readyCount}</p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card className="border-none shadow-md bg-gradient-to-br from-amber-500/10 to-amber-600/5">
+                    <CardContent className="p-6">
+                        <div className="flex items-center gap-4">
+                            <div className="h-12 w-12 rounded-xl bg-amber-500/20 flex items-center justify-center">
+                                <AlertCircle className="h-6 w-6 text-amber-500" />
+                            </div>
+                            <div>
+                                <p className="text-sm text-muted-foreground">이미지 부족</p>
+                                <p className="text-3xl font-bold">{notReadyCount}</p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            {/* Search and Filters */}
+            <div className="flex flex-col md:flex-row gap-4 items-center">
+                <div className="relative flex-1 group w-full">
+                    <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground group-focus-within:text-primary transition-colors" />
+                    <Input
+                        placeholder="상품명으로 검색..."
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        className="pl-12 h-12 rounded-2xl border-none bg-accent/50 focus-visible:ring-2 focus-visible:ring-primary/20 transition-all text-base w-full"
+                    />
+                </div>
+                <div className="flex items-center gap-2">
+                    <input
+                        type="checkbox"
+                        id="selectAll"
+                        checked={selectedIds.size === readyCount && readyCount > 0}
+                        onChange={(e) => toggleSelectAll(e.target.checked)}
+                        className="h-5 w-5 rounded border-gray-300"
+                    />
+                    <label htmlFor="selectAll" className="text-sm text-muted-foreground">
+                        등록 가능 전체 선택
+                    </label>
+                </div>
+                <Button
+                    variant="outline"
+                    className="h-12 rounded-2xl px-6"
+                    onClick={() => window.location.href = '/market-products'}
+                >
+                    마켓 상품 보기
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+            </div>
+
+            {/* Product List */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {loading ? (
+                    <div className="col-span-full h-80 flex flex-col items-center justify-center space-y-4">
+                        <div className="h-12 w-12 rounded-full border-4 border-primary/20 border-t-primary animate-spin" />
+                        <p className="text-muted-foreground font-medium animate-pulse">상품 데이터를 불러오는 중...</p>
+                    </div>
+                ) : error ? (
+                    <Card className="col-span-full border-2 border-destructive/20 bg-destructive/5">
+                        <CardContent className="flex flex-col items-center py-12 text-center">
+                            <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+                            <h3 className="text-xl font-bold mb-2">오류 발생</h3>
+                            <p className="text-muted-foreground">{error}</p>
+                            <Button className="mt-6 rounded-xl" variant="outline" onClick={fetchProducts}>다시 시도</Button>
+                        </CardContent>
+                    </Card>
+                ) : filteredItems.length === 0 ? (
+                    <div className="col-span-full py-20 text-center">
+                        <div className="h-20 w-20 bg-accent rounded-full flex items-center justify-center mx-auto mb-6">
+                            <CheckCircle2 className="h-10 w-10 text-muted-foreground/50" />
+                        </div>
+                        <h3 className="text-2xl font-bold text-foreground mb-2">등록 대기 상품이 없습니다</h3>
+                        <p className="text-muted-foreground">가공 페이지에서 상품을 가공해 주세요.</p>
+                        <Button className="mt-8 rounded-xl h-11 px-8" onClick={() => window.location.href = '/processing'}>가공 페이지로 이동</Button>
+                    </div>
+                ) : (
+                    filteredItems.map((item) => {
+                        const isReady = isReadyForRegistration(item);
+                        const isRegistering = registeringIds.has(item.id);
+                        const isSelected = selectedIds.has(item.id);
+
+                        return (
+                            <Card
+                                key={item.id}
+                                className={cn(
+                                    "group overflow-hidden border-2 shadow-md hover:shadow-2xl transition-all duration-500 rounded-3xl bg-card/40 backdrop-blur-xl",
+                                    isSelected ? "border-primary" : "border-transparent",
+                                    !isReady && "opacity-70"
+                                )}
+                            >
+                                {/* Image Preview */}
+                                <div className="aspect-[4/3] relative overflow-hidden bg-muted">
+                                    {item.processed_image_urls && item.processed_image_urls.length > 0 ? (
+                                        <img
+                                            src={item.processed_image_urls[0]}
+                                            alt={item.name}
+                                            className="object-cover w-full h-full transition-transform duration-700 group-hover:scale-110"
+                                        />
+                                    ) : (
+                                        <div className="w-full h-full flex flex-col items-center justify-center text-muted-foreground/30 space-y-2">
+                                            <ShoppingCart className="h-12 w-12" />
+                                            <span className="text-xs font-medium uppercase tracking-widest">No Image</span>
+                                        </div>
+                                    )}
+
+                                    {/* Select Checkbox */}
+                                    {isReady && (
+                                        <div className="absolute top-4 left-4">
+                                            <input
+                                                type="checkbox"
+                                                checked={isSelected}
+                                                onChange={(e) => toggleSelect(item.id, e.target.checked)}
+                                                className="h-5 w-5 rounded border-2 border-white bg-white/80 backdrop-blur-sm"
+                                            />
+                                        </div>
+                                    )}
+
+                                    {/* Image Count Badge */}
+                                    <div className="absolute top-4 right-4">
+                                        <Badge
+                                            className={cn(
+                                                "backdrop-blur-md border-0 text-[10px] font-bold tracking-widest uppercase py-1",
+                                                isReady ? "bg-emerald-500/80 text-white" : "bg-amber-500/80 text-white"
+                                            )}
+                                        >
+                                            이미지 {item.imagesCount}/5
+                                        </Badge>
+                                    </div>
+                                </div>
+
+                                <CardContent className="p-5 space-y-4">
+                                    <div className="space-y-1">
+                                        <h3 className="font-bold text-lg leading-tight truncate group-hover:text-primary transition-colors">
+                                            {item.processed_name || item.name}
+                                        </h3>
+                                        {item.processed_name && (
+                                            <p className="text-xs text-muted-foreground line-through opacity-50 truncate">
+                                                {item.name}
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    <div className="flex items-center justify-between text-sm py-3 border-y border-foreground/5">
+                                        <div className="flex flex-col">
+                                            <span className="text-muted-foreground text-[10px] uppercase font-bold tracking-tighter">판매가</span>
+                                            <span className="font-bold text-base text-primary">{item.selling_price.toLocaleString()}원</span>
+                                        </div>
+                                        <div className="flex flex-col items-end">
+                                            <span className="text-muted-foreground text-[10px] uppercase font-bold tracking-tighter">상태</span>
+                                            <Badge variant="secondary" className="text-xs">
+                                                {isReady ? "등록 가능" : "이미지 부족"}
+                                            </Badge>
+                                        </div>
+                                    </div>
+                                </CardContent>
+
+                                <CardFooter className="px-5 pb-5 pt-0">
+                                    <Button
+                                        className={cn(
+                                            "w-full rounded-2xl font-bold transition-all shadow-lg",
+                                            isReady
+                                                ? "bg-primary hover:bg-primary/90 shadow-primary/20"
+                                                : "bg-muted text-muted-foreground cursor-not-allowed"
+                                        )}
+                                        size="sm"
+                                        onClick={() => handleRegister(item.id)}
+                                        disabled={!isReady || isRegistering}
+                                    >
+                                        {isRegistering ? (
+                                            <>
+                                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                                등록 중...
+                                            </>
+                                        ) : isReady ? (
+                                            <>
+                                                <Upload className="mr-2 h-4 w-4" />
+                                                쿠팡 등록
+                                            </>
+                                        ) : (
+                                            "이미지 추가 필요"
+                                        )}
+                                    </Button>
+                                </CardFooter>
+                            </Card>
+                        );
+                    })
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -16,7 +16,9 @@ import {
     Wand2,
     BarChart3,
     Download,
-    Database
+    Database,
+    Upload,
+    Store
 } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
@@ -34,6 +36,8 @@ const menuGroups = [
         items: [
             { name: "상품 관리", href: "/products", icon: Package },
             { name: "상품 가공", href: "/processing", icon: Wand2 },
+            { name: "상품 등록", href: "/registration", icon: Upload },
+            { name: "마켓 상품", href: "/market-products", icon: Store },
             { name: "상품 소싱", href: "/sourcing", icon: Search },
             { name: "벤치마크", href: "/benchmarks", icon: BarChart3 },
         ]
@@ -58,6 +62,7 @@ const menuGroups = [
         ]
     }
 ];
+
 
 export default function Sidebar() {
     const pathname = usePathname();


### PR DESCRIPTION
## 변경 요약
- 프론트
  - `/registration`: 가공 완료(COMPLETED) + DRAFT 상품을 조회해 쿠팡 등록(단건/일괄) 가능
  - `/market-products`: 마켓(쿠팡) 등록 상품 목록 조회/표시
  - Sidebar 메뉴에 `상품 등록`, `마켓 상품` 추가
- 백엔드
  - `GET /api/products/`에 `processingStatus`, `status` 필터 지원
  - `GET /api/market/products`, `GET /api/market/listings` 엔드포인트 추가
  - `app/main.py`에 `/api/market` 라우터 등록

## 확인 방법
1) 프론트에서 `상품 등록` 진입 → 등록 대기/가능 상품이 표시되는지 확인
2) 단건 등록: `쿠팡 등록` 클릭 시 `/api/coupang/register/{productId}?autoFix=true&wait=true` 호출 확인
3) 일괄 등록: 체크 후 `선택 등록` 클릭 시 `/api/coupang/register/bulk` 호출 확인
4) `마켓 상품` 화면에서 `/api/market/products` 조회가 정상인지 확인

## 비고
- 이번 PR은 `.agent*.md`, `GEMINI.md` 등 문서성 파일은 포함하지 않습니다.
