### PR TITLE
fix: 쿠팡 업데이트 최신 리스팅 선택 및 이미지 규격(10MB) 강제

### DIFF
--- a/app/coupang_sync.py
+++ b/app/coupang_sync.py
@@ -522,11 +522,16 @@ def update_product_on_coupang(session: Session, account_id: uuid.UUID, product_i
     if not account or not product:
         return False, "계정 또는 상품을 찾을 수 없습니다"
     
-    listing = session.execute(
-        select(MarketListing)
-        .where(MarketListing.market_account_id == account.id)
-        .where(MarketListing.product_id == product.id)
-    ).scalars().first()
+    listing = (
+        session.execute(
+            select(MarketListing)
+            .where(MarketListing.market_account_id == account.id)
+            .where(MarketListing.product_id == product.id)
+            .order_by(MarketListing.linked_at.desc())
+        )
+        .scalars()
+        .first()
+    )
     
     if not listing:
         return False, "쿠팡에 등록된 리스팅 정보를 찾을 수 없습니다(먼저 등록 필요)"


### PR DESCRIPTION
## 변경 요약
- `update_product_on_coupang`에서 상품별 최신 `MarketListing(linked_at desc)`을 사용하여 올바른 `sellerProductId`로 업데이트하도록 수정
- 이미지 처리에서 쿠팡 DETAIL 규격(최대 10MB, 500~5000) 강제
  - 변환 실패 시 원본 업로드로 fallback 하지 않고 스킵하여 규격 미준수 이미지 업로드 방지

## 기대 효과
- 과거/삭제된 sellerProductId를 잘못 업데이트하는 문제 방지
- DETAIL 이미지 규격 반려(10MB/해상도) 재발 방지
