### PR TITLE
fix: 쿠팡 상태 동기화 최신화 및 이미지 규격 보정

### DIFF
--- a/app/services/image_processing.py
+++ b/app/services/image_processing.py
@@ -69,17 +69,21 @@ class ImageProcessingService:
             MIN_DIM = 500
             MAX_DIM = 5000
             
+            # 1) 비율을 최대한 유지하면서 min/max 범위로 맞춤
             if new_width < MIN_DIM or new_height < MIN_DIM:
-                # 500x500 미만인 경우 비율을 유지하며 최소 크기로 조정
                 ratio = max(MIN_DIM / new_width, MIN_DIM / new_height)
-                new_width = int(new_width * ratio)
-                new_height = int(new_height * ratio)
-            
+                new_width = int(math.ceil(new_width * ratio))
+                new_height = int(math.ceil(new_height * ratio))
+
             if new_width > MAX_DIM or new_height > MAX_DIM:
-                # 5000x5000을 초과하는 경우 비율을 유지하며 최대 크기로 조정
                 ratio = min(MAX_DIM / new_width, MAX_DIM / new_height)
-                new_width = int(new_width * ratio)
-                new_height = int(new_height * ratio)
+                new_width = int(math.floor(new_width * ratio))
+                new_height = int(math.floor(new_height * ratio))
+
+            # 2) max clamp 과정에서 반대 축이 500 미만으로 내려갈 수 있어(예: 세로 5000 제한으로 가로가 <500),
+            #    최종적으로 각 축을 독립적으로 [500, 5000]에 맞춥니다(비율이 약간 변형될 수 있음).
+            new_width = max(MIN_DIM, min(MAX_DIM, int(new_width)))
+            new_height = max(MIN_DIM, min(MAX_DIM, int(new_height)))
 
             img = cv2.resize(img, (new_width, new_height), interpolation=cv2.INTER_LANCZOS4)
             


### PR DESCRIPTION
## 변경 요약
- `POST /api/coupang/sync-status/{productId}`
  - 활성 쿠팡 계정 기준으로 조회
  - `MarketListing.linked_at desc` 최신 리스팅을 대상으로 동기화
  - 응답에 `sellerProductId`, `previousRejectionReason`, `rejectionReason` 포함
- `sync_market_listing_status`
  - `statusName`을 자동화 친화적으로 정규화: `DENIED/DELETED/...`
  - `승인반려/반려/상품삭제` 등 한국어 상태도 대응
- 이미지 처리
  - 리사이즈 과정에서 `5000` 상한 적용 후 반대축이 `500` 미만으로 내려가는 edge case 보정

## 배경
- 동일 productId에 여러 sellerProductId(리스팅 히스토리)가 존재하는 상황에서, 비최신 리스팅을 기준으로 sync/update가 실행되는 문제가 있었습니다.
- DETAIL 이미지 규격 반려를 방지하기 위해 리사이즈 결과의 최소 해상도 보장을 강화했습니다.
