### PR TITLE
chore: 쿠팡 API 문서 파일 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ backend.log
 scripts/seed_browser_test.py
 scripts/test_coupang_bulk_integration.py
 scripts/test_coupang_bulk_registration.py
+
+docs/api_docs/coupang/*.pdf
+docs/api_docs/coupang/*.docx
+docs/api_docs/coupang/*:Zone.Identifier


### PR DESCRIPTION
## 변경 요약
- `.gitignore`에 아래 패턴 추가
  - `docs/api_docs/coupang/*.pdf`
  - `docs/api_docs/coupang/*.docx`
  - `docs/api_docs/coupang/*:Zone.Identifier`

## 배경
- 로컬에 저장된 쿠팡 API 문서(PDF/DOCX) 및 Windows Zone.Identifier 메타 파일이 `git status`에 계속 표시되어 작업 흐름을 방해함.
- 소스코드/운영에 영향 없는 파일이므로 git 추적 대상에서 제외.
