### PR TITLE
fix: 쿠팡 APPROVAL_REQUESTED 상태 정규화

### DIFF
--- a/app/coupang_sync.py
+++ b/app/coupang_sync.py
@@ -284,6 +284,8 @@ def sync_market_listing_status(session: Session, listing_id: uuid.UUID) -> tuple
                 status_name = "DENIED"
             elif su == "DELETED" or "삭제" in s or s == "상품삭제":
                 status_name = "DELETED"
+            elif su == "APPROVAL_REQUESTED":
+                status_name = "APPROVING"
             elif su in {"IN_REVIEW", "SAVED", "APPROVING", "APPROVED", "PARTIAL_APPROVED"}:
                 status_name = su
             elif s == "심사중":

--- a/frontend/src/app/products/page.tsx
+++ b/frontend/src/app/products/page.tsx
@@ -15,6 +15,9 @@ function normalizeCoupangStatus(status?: string | null): string | null {
     if (!s) return null;
 
     const su = s.toUpperCase();
+    if (su === "APPROVAL_REQUESTED") {
+        return "APPROVING";
+    }
     if (
         su === "DENIED" ||
         su === "DELETED" ||

--- a/frontend/src/app/registration/page.tsx
+++ b/frontend/src/app/registration/page.tsx
@@ -35,6 +35,9 @@ function normalizeCoupangStatus(status?: string | null): string | null {
     if (!s) return null;
 
     const su = s.toUpperCase();
+    if (su === "APPROVAL_REQUESTED") {
+        return "APPROVING";
+    }
     if (
         su === "DENIED" ||
         su === "DELETED" ||

--- a/scripts/coupang_fix_denied_images.py
+++ b/scripts/coupang_fix_denied_images.py
@@ -65,6 +65,8 @@ def _normalize_status(status: object | None) -> str | None:
         return None
 
     su = s.upper()
+    if su == "APPROVAL_REQUESTED":
+        return "APPROVING"
     if su in {
         "DENIED",
         "DELETED",


### PR DESCRIPTION
## 변경 요약
- 쿠팡 상태값 중 `APPROVAL_REQUESTED`를 표준 코드인 `APPROVING`으로 정규화
  - 백엔드: `app/coupang_sync.py#sync_market_listing_status`
  - 프론트: `registration/products` 페이지의 `normalizeCoupangStatus`
  - 스크립트: `scripts/coupang_fix_denied_images.py` 상태 정규화

## 배경
- DB에 `APPROVAL_REQUESTED` 같은 값이 남아 있으면 프론트/자동화에서 상태 분기가 불안정해짐.
- `APPROVING`으로 통일하여 모니터링/필터링/배치 처리 일관성 확보.
