### PR TITLE
feat: 쿠팡 운영 루틴(모니터링+자동복구) 스크립트 추가

### DIFF
--- a/scripts/coupang_status_report.py
+++ b/scripts/coupang_status_report.py
@@ -1,0 +1,154 @@
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from datetime import datetime
+
+from sqlalchemy import select
+
+# 프로젝트 루트를 sys.path에 추가
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.session_factory import session_factory
+from app.models import MarketAccount, MarketListing
+
+
+def _safe_str(v: object | None) -> str:
+    if v is None:
+        return ""
+    try:
+        return str(v)
+    except Exception:
+        return ""
+
+
+def _extract_rejection_text(rejection_reason: dict | None) -> str | None:
+    if not isinstance(rejection_reason, dict):
+        return None
+
+    for k in ("reason", "comment", "message"):
+        v = rejection_reason.get(k)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+
+    return None
+
+
+def _normalize_status(status: object | None) -> str | None:
+    if status is None:
+        return None
+
+    s = _safe_str(status).strip()
+    if not s:
+        return None
+
+    su = s.upper()
+    if su == "APPROVAL_REQUESTED":
+        return "APPROVING"
+
+    if su in {
+        "DENIED",
+        "DELETED",
+        "IN_REVIEW",
+        "SAVED",
+        "APPROVING",
+        "APPROVED",
+        "PARTIAL_APPROVED",
+    }:
+        return su
+
+    if s in {"승인반려", "반려"}:
+        return "DENIED"
+    if s in {"임시저장", "임시저장중"}:
+        return "SAVED"
+    if s == "승인대기중":
+        return "APPROVING"
+    if s == "심사중":
+        return "IN_REVIEW"
+    if s == "승인완료":
+        return "APPROVED"
+    if s == "부분승인완료":
+        return "PARTIAL_APPROVED"
+    if "삭제" in s or s == "상품삭제":
+        return "DELETED"
+
+    return s
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="쿠팡 상태 리포트(최신 MarketListing 기준)")
+    parser.add_argument("--scan-limit", type=int, default=5000, help="MarketListing 조회 최대 건수")
+    parser.add_argument("--sample-limit", type=int, default=20, help="비정상 상태 샘플 출력 건수")
+    parser.add_argument(
+        "--out",
+        default=f"/tmp/coupang_status_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json",
+        help="결과 JSON 저장 경로",
+    )
+    args = parser.parse_args()
+
+    with session_factory() as session:
+        acct = session.scalars(
+            select(MarketAccount)
+            .where(MarketAccount.market_code == "COUPANG")
+            .where(MarketAccount.is_active == True)
+        ).first()
+        if not acct:
+            raise RuntimeError("활성 상태의 쿠팡 계정을 찾을 수 없습니다.")
+
+        listings = session.scalars(
+            select(MarketListing)
+            .where(MarketListing.market_account_id == acct.id)
+            .order_by(MarketListing.linked_at.desc())
+            .limit(int(args.scan_limit))
+        ).all()
+
+        latest_by_product: dict[str, MarketListing] = {}
+        for l in listings:
+            pid = _safe_str(l.product_id)
+            if pid and pid not in latest_by_product:
+                latest_by_product[pid] = l
+
+        rows = []
+        for pid, l in latest_by_product.items():
+            rows.append(
+                {
+                    "productId": pid,
+                    "sellerProductId": _safe_str(l.market_item_id) or None,
+                    "coupangStatus": _normalize_status(l.coupang_status),
+                    "linkedAt": l.linked_at.isoformat() if l.linked_at else None,
+                    "rejectionReasonText": _extract_rejection_text(l.rejection_reason),
+                }
+            )
+
+    counts = Counter([r.get("coupangStatus") for r in rows])
+
+    non_ok = []
+    for r in rows:
+        st = r.get("coupangStatus")
+        if st not in {"APPROVED", "PARTIAL_APPROVED"}:
+            non_ok.append(r)
+
+    result = {
+        "generatedAt": datetime.now().isoformat(),
+        "latestCount": len(rows),
+        "countsByCoupangStatus": dict(counts),
+        "sampleNonApproved": non_ok[: int(args.sample_limit)],
+    }
+
+    out_path = str(args.out)
+    out_dir = os.path.dirname(out_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(f"saved: {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_coupang_maintenance.sh
+++ b/scripts/run_coupang_maintenance.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 쿠팡 운영 루틴(모니터링 + 자동복구)
+# - 모니터링: 최신 MarketListing 기준 상태 리포트 생성
+# - 자동복구: 이미지 규격 DENIED 대상에 대해 process→update→sync-status 수행
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PY="$ROOT_DIR/.venv/bin/python"
+
+if [ ! -x "$PY" ]; then
+  echo "[오류] 가상환경 파이썬을 찾을 수 없습니다: $PY" >&2
+  exit 1
+fi
+
+OUT_DIR="${OUT_DIR:-/tmp}"
+NOW="$(date +%Y%m%d_%H%M%S)"
+
+REPORT_OUT="$OUT_DIR/coupang_status_report_${NOW}.json"
+FIX_OUT="$OUT_DIR/coupang_fix_denied_images_${NOW}.json"
+
+SCAN_LIMIT="${SCAN_LIMIT:-5000}"
+SAMPLE_LIMIT="${SAMPLE_LIMIT:-20}"
+
+FIX_LIMIT="${FIX_LIMIT:-50}"
+FIX_MIN_IMAGES="${FIX_MIN_IMAGES:-5}"
+FIX_PROCESS_TIMEOUT="${FIX_PROCESS_TIMEOUT:-240}"
+FIX_PROCESS_INTERVAL="${FIX_PROCESS_INTERVAL:-3}"
+FIX_SYNC_TIMEOUT="${FIX_SYNC_TIMEOUT:-180}"
+FIX_SYNC_INTERVAL="${FIX_SYNC_INTERVAL:-10}"
+
+DO_FIX="${DO_FIX:-1}"
+DRY_RUN="${DRY_RUN:-0}"
+
+echo "[쿠팡] 상태 리포트 생성: $REPORT_OUT"
+"$PY" "$ROOT_DIR/scripts/coupang_status_report.py" \
+  --scan-limit "$SCAN_LIMIT" \
+  --sample-limit "$SAMPLE_LIMIT" \
+  --out "$REPORT_OUT"
+
+if [ "$DO_FIX" = "1" ]; then
+  echo "[쿠팡] 이미지 반려 자동 처리 실행: $FIX_OUT"
+
+  EXTRA_ARGS=()
+  if [ "$DRY_RUN" = "1" ]; then
+    EXTRA_ARGS+=(--dry-run)
+  fi
+
+  "$PY" "$ROOT_DIR/scripts/coupang_fix_denied_images.py" \
+    --limit "$FIX_LIMIT" \
+    --min-images "$FIX_MIN_IMAGES" \
+    --process-timeout "$FIX_PROCESS_TIMEOUT" \
+    --process-interval "$FIX_PROCESS_INTERVAL" \
+    --sync-timeout "$FIX_SYNC_TIMEOUT" \
+    --sync-interval "$FIX_SYNC_INTERVAL" \
+    --out "$FIX_OUT" \
+    "${EXTRA_ARGS[@]}"
+else
+  echo "[쿠팡] DO_FIX=0 이므로 자동 복구를 건너뜁니다."
+fi


### PR DESCRIPTION
## 변경 요약
- `scripts/coupang_status_report.py`
  - 최신 `MarketListing(linked_at desc)` 기준 쿠팡 상태 리포트 생성
  - 상태 카운트/샘플(`sampleNonApproved`) 출력 및 JSON 저장
- `scripts/run_coupang_maintenance.sh`
  - 상태 리포트 실행 + (옵션) 이미지 규격 DENIED 자동 복구 스크립트 실행 래퍼
  - 크론/수동 실행용 환경변수(OUT_DIR, DO_FIX, DRY_RUN 등) 지원

## 사용 예시
```bash
# 리포트만
DO_FIX=0 bash scripts/run_coupang_maintenance.sh

# 리포트 + 자동 복구(dry-run)
DRY_RUN=1 bash scripts/run_coupang_maintenance.sh

# 리포트 + 자동 복구(실행)
bash scripts/run_coupang_maintenance.sh
```
