### PR TITLE
fix: 상품 목록 500 에러 및 공급사 수집 관련 버그 수정

### DIFF
--- a/app/api/endpoints/suppliers.py
+++ b/app/api/endpoints/suppliers.py
@@ -97,6 +97,7 @@ def trigger_ownerclan_items(
     _cleanup_stale_jobs(session, supplier_code="ownerclan")
     _ensure_no_running_job(session, supplier_code="ownerclan", job_type="ownerclan_items_raw")
     job = _enqueue_job(session, "ownerclan", "ownerclan_items_raw", payload.params)
+    session.commit()
     background_tasks.add_task(start_background_ownerclan_job, session_factory, uuid.UUID(str(job.id)))
     return {"jobId": str(job.id)}
 
@@ -110,6 +111,7 @@ def trigger_ownerclan_orders(
     _cleanup_stale_jobs(session, supplier_code="ownerclan")
     _ensure_no_running_job(session, supplier_code="ownerclan", job_type="ownerclan_orders_raw")
     job = _enqueue_job(session, "ownerclan", "ownerclan_orders_raw", payload.params)
+    session.commit()
     background_tasks.add_task(start_background_ownerclan_job, session_factory, uuid.UUID(str(job.id)))
     return {"jobId": str(job.id)}
 
@@ -123,6 +125,7 @@ def trigger_ownerclan_qna(
     _cleanup_stale_jobs(session, supplier_code="ownerclan")
     _ensure_no_running_job(session, supplier_code="ownerclan", job_type="ownerclan_qna_raw")
     job = _enqueue_job(session, "ownerclan", "ownerclan_qna_raw", payload.params)
+    session.commit()
     background_tasks.add_task(start_background_ownerclan_job, session_factory, uuid.UUID(str(job.id)))
     return {"jobId": str(job.id)}
 
@@ -136,6 +139,7 @@ def trigger_ownerclan_categories(
     _cleanup_stale_jobs(session, supplier_code="ownerclan")
     _ensure_no_running_job(session, supplier_code="ownerclan", job_type="ownerclan_categories_raw")
     job = _enqueue_job(session, "ownerclan", "ownerclan_categories_raw", payload.params)
+    session.commit()
     background_tasks.add_task(start_background_ownerclan_job, session_factory, uuid.UUID(str(job.id)))
     return {"jobId": str(job.id)}
 

--- a/app/main.py
+++ b/app/main.py
@@ -34,8 +34,12 @@ app.include_router(market.router, prefix="/api/market", tags=["Market"])
 # 브라우저가 8888 오리진으로 따라가며 CORS에 막혀 Axios가 Network Error가 날 수 있다.
 # 따라서 슬래시 없는 엔드포인트를 별칭(alias)로 제공해 redirect 자체를 제거한다.
 @app.get("/api/products", response_model=List[ProductResponse], include_in_schema=False)
-def list_products_alias(session: Session = Depends(get_session)):
-    return products.list_products(session=session)
+def list_products_alias(
+    session: Session = Depends(get_session),
+    processing_status: str | None = Query(default=None, alias="processingStatus"),
+    status: str | None = Query(default=None),
+):
+    return products.list_products(session=session, processing_status=processing_status, status=status)
 
 
 @app.get("/api/benchmarks", include_in_schema=False)

--- a/app/services/sourcing_service.py
+++ b/app/services/sourcing_service.py
@@ -258,7 +258,7 @@ class SourcingService:
                 ) or 0
 
                 insert_stmt = (
-                    insert(SourcingCandidate.__table__)
+                    insert(SourcingCandidate)
                     .values(
                         supplier_code="ownerclan",
                         supplier_item_id=str(raw.item_code),


### PR DESCRIPTION
상품 목록 조회 시 발생하는 500 에러와 오너클랜 상품 수집이 작동하지 않던 치명적인 버그들을 해결한 PR입니다.

### 주요 수정 내용
1. **app/main.py**: `list_products_alias`에서 쿼리 파라미터를 정확히 전달하도록 수정하여 SQLAlchemy 어댑터 오류(500 에러) 해결
2. **app/api/endpoints/suppliers.py**: 수집 트리거 엔드포인트에서 `session.commit()` 누락 수정으로 작업 정보가 DB에 저장되지 않던 문제 해결
3. **app/services/sourcing_service.py**: `SourcingCandidate` 삽입 시 멀티 DB 환경에서의 바인딩 오류 해결

수정 후 수집 작업이 정상적으로 수행되고, 소싱 후보 데이터가 자동으로 생성되는 것을 확인했습니다.