### PR TITLE
fix: 임베딩 768 백필 스크립트 및 검증 수정

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -68,8 +68,8 @@ class EmbeddingIn(BaseModel):
     @field_validator("embedding")
     @classmethod
     def validate_embedding(cls, v: list[float]) -> list[float]:
-        if len(v) != 3:
-            raise ValueError("embedding 길이는 3이어야 합니다")
+        if len(v) != 768:
+            raise ValueError("embedding 길이는 768이어야 합니다")
         return v
 
 

--- a/scripts/backfill_embeddings_768.py
+++ b/scripts/backfill_embeddings_768.py
@@ -1,0 +1,145 @@
+import argparse
+import os
+import sys
+import asyncio
+
+sys.path.append(os.getcwd())
+
+from app.db import SessionLocal
+from app.embedding_service import EmbeddingService
+from app.models import Embedding
+
+
+async def _apply_backfill(
+    base_url: str,
+    model: str,
+    start_id: int,
+    end_id: int | None,
+    batch_size: int,
+    commit_every: int,
+    sleep_seconds: float,
+) -> int:
+    service = EmbeddingService(base_url=base_url, model=model)
+
+    total_scanned = 0
+    total_candidate = 0
+    total_updated = 0
+    total_failed = 0
+
+    last_id = int(start_id)
+
+    with SessionLocal() as session:
+        while True:
+            q = session.query(Embedding).filter(Embedding.id > last_id)
+            if end_id is not None:
+                q = q.filter(Embedding.id <= int(end_id))
+
+            rows = q.order_by(Embedding.id.asc()).limit(int(batch_size)).all()
+            if not rows:
+                break
+
+            for row in rows:
+                last_id = int(row.id)
+                total_scanned += 1
+
+                emb = row.embedding
+                if isinstance(emb, list) and len(emb) == 768:
+                    continue
+
+                total_candidate += 1
+
+                text = (row.content or "").strip()
+                if not text:
+                    total_failed += 1
+                    continue
+
+                new_emb = await service.generate_embedding(text)
+                if not isinstance(new_emb, list) or len(new_emb) != 768:
+                    total_failed += 1
+                    continue
+
+                row.embedding = new_emb
+                total_updated += 1
+
+                if commit_every > 0 and total_updated % int(commit_every) == 0:
+                    session.commit()
+                    session.expire_all()
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(float(sleep_seconds))
+
+        session.commit()
+
+    print(
+        f"scanned={total_scanned} candidates={total_candidate} updated={total_updated} failed={total_failed} last_id={last_id}"
+    )
+
+    return 0 if total_failed == 0 else 2
+
+
+def _dry_run(start_id: int, end_id: int | None, batch_size: int) -> int:
+    total_scanned = 0
+    total_candidate = 0
+    last_id = int(start_id)
+
+    with SessionLocal() as session:
+        while True:
+            q = session.query(Embedding).filter(Embedding.id > last_id)
+            if end_id is not None:
+                q = q.filter(Embedding.id <= int(end_id))
+
+            rows = q.order_by(Embedding.id.asc()).limit(int(batch_size)).all()
+            if not rows:
+                break
+
+            for row in rows:
+                last_id = int(row.id)
+                total_scanned += 1
+                emb = row.embedding
+                if isinstance(emb, list) and len(emb) == 768:
+                    continue
+                total_candidate += 1
+
+    print(f"dry_run scanned={total_scanned} candidates={total_candidate} last_id={last_id}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+
+    parser.add_argument("--base-url", dest="baseUrl", type=str, default=os.getenv("EMBEDDING_BASE_URL", "http://localhost:11434"))
+    parser.add_argument("--model", type=str, default=os.getenv("EMBEDDING_MODEL", "nomic-embed-text"))
+
+    parser.add_argument("--start-id", dest="startId", type=int, default=0)
+    parser.add_argument("--end-id", dest="endId", type=int, default=None)
+    parser.add_argument("--batch-size", dest="batchSize", type=int, default=200)
+    parser.add_argument("--commit-every", dest="commitEvery", type=int, default=50)
+    parser.add_argument("--sleep", dest="sleepSeconds", type=float, default=0.0)
+
+    args = parser.parse_args()
+
+    if not args.apply:
+        print("dry-run 모드입니다(--apply를 주면 DB에 반영됩니다)")
+        return _dry_run(args.startId, args.endId, args.batchSize)
+
+    print(
+        "apply 모드입니다. embeddings.embedding(768) 백필을 수행합니다. "
+        "(DB_URL/EMBEDDING_BASE_URL/EMBEDDING_MODEL 환경변수 설정을 확인하세요)"
+    )
+
+    return asyncio.run(
+        _apply_backfill(
+            base_url=str(args.baseUrl),
+            model=str(args.model),
+            start_id=int(args.startId),
+            end_id=int(args.endId) if args.endId is not None else None,
+            batch_size=int(args.batchSize),
+            commit_every=int(args.commitEvery),
+            sleep_seconds=float(args.sleepSeconds),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 변경 요약
- `/embeddings` 입력 검증이 기존 3차원(`len==3`)으로 남아 있어 768 전환 후 요청이 실패할 수 있어 **768로 수정**했습니다.
- `embeddings` 테이블의 기존 레코드(구 3차원 데이터)를 768 차원으로 재생성하기 위한 **백필 스크립트** `scripts/backfill_embeddings_768.py`를 추가했습니다.

## 운영 적용 가이드(요약)
1) Alembic 마이그레이션으로 `embeddings.embedding`을 `vector(768)`로 변경
2) 앱 배포(768 임베딩 생성/저장 로직이 활성화된 상태)
3) 백필 실행(드라이런 후 apply)

## 백필 실행 예시
- dry-run(대상 수/범위 확인)
  - `./.venv/bin/python scripts/backfill_embeddings_768.py --start-id 0 --batch-size 200`
- apply(실제 반영)
  - `./.venv/bin/python scripts/backfill_embeddings_768.py --apply --start-id 0 --batch-size 200 --commit-every 50`

## 주의사항
- 백필은 외부 임베딩 서버(Ollama 등) 호출이 포함되므로, 운영에서는 쿼터/속도/부하를 고려해 `--sleep` 옵션이나 범위 제한(`--start-id/--end-id`)을 권장합니다.